### PR TITLE
Add formal grammar definition of format

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,7 @@ date ::= year "-" month "-" day ;
 createdDate ::= date ;
 completedDate ::= date ;
 
-priorityClass ::= "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" |
-           "K" | "L" | "M" | "N" | "O" | "P" | "Q" | "R" | "S" | "T" |
-           "U" | "V" | "W" | "X" | "Y" | "Z" ;
+priorityClass ::= [A-Z] ;
 priority ::= "(" priorityClass ")" ;
 
 space ::= whitespace + ; 


### PR DESCRIPTION
As discussed in #18, a formal grammar would help implementors and tool makers create applications to a common format.

This PR proposes a formal grammar for the todo.txt format.

It would require a reference implementation and the definition of some test cases to test this grammar thoroughly, which is outside the scope of this pull request.